### PR TITLE
Fix flaky Cypress test: Accordion animation race

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,1 +1,23 @@
 import 'cypress-real-events';
+
+// MUI's Accordion expand transition races with realClick on elements inside
+// it (e.g. the Table tab in DataContainer), causing intermittent failures.
+// Disabling CSS transitions/animations keeps element positions stable.
+Cypress.on('window:before:load', (win) => {
+  const inject = () => {
+    const style = win.document.createElement('style');
+    style.innerHTML = `
+      *, *::before, *::after {
+        transition: none !important;
+        animation: none !important;
+      }
+    `;
+    win.document.head.appendChild(style);
+  };
+
+  if (win.document.head) {
+    inject();
+  } else {
+    win.document.addEventListener('DOMContentLoaded', inject);
+  }
+});


### PR DESCRIPTION
## Summary
- `should render the advanced data` intermittently failed (~50% locally) because it `realClick`s the Table tab inside a MUI Accordion immediately after triggering the expand animation, sometimes clicking before layout settles and missing the tab switch.
- This is unrelated to any dependency version - reproduced identically on `main` before and after the nuqs 2.8.9 to 2.9.2 bump in #676, which is what surfaced it (bad luck, not a regression).
- Fix: disable CSS transitions/animations globally during Cypress runs via a style injection in `cypress/support/e2e.ts`, a standard pattern for MUI + Cypress flake.

## Test plan
- [x] Ran the full spec 6/6 clean locally with the fix (previously failing ~50% of runs)
- [x] Confirmed CI passes

Generated with Claude Code